### PR TITLE
Get ip from config as port

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -30,10 +30,12 @@ driver.xmxMemory = 1g
 
 # application configuration
 appConf{
-	# the port on which to deploy the apis
-	web.services.port=8097
-	# implicit akka timeout
-	timeout=1000000
+  # this ip on which to deploy the apis
+  web.services.ip=9.91.12.117
+  # the port on which to deploy the apis
+  web.services.port=8097
+  # implicit akka timeout
+  timeout=1000000
   #implicit sleep before sending init message
   init.sleep=3000
   #The port where the range for actor system starts

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -31,7 +31,7 @@ driver.xmxMemory = 1g
 # application configuration
 appConf{
   # this ip on which to deploy the apis
-  web.services.ip=9.91.12.117
+  web.services.ip=0.0.0.0
   # the port on which to deploy the apis
   web.services.port=8097
   # implicit akka timeout

--- a/src/main/scala/server/Controller.scala
+++ b/src/main/scala/server/Controller.scala
@@ -31,7 +31,8 @@ import spray.json.DefaultJsonProtocol._
   var StateKey = "state"
   var ResultKey = "result"
 
-
+  // Get ip from config, "0.0.0.0" as default
+  val webIp = getValueFromConfig(config, "appConf.web.services.ip", "0.0.0.0")
   val webPort = getValueFromConfig(config, "appConf.web.services.port", 8097)
 
   val logger = LoggerFactory.getLogger(getClass)
@@ -39,7 +40,7 @@ import spray.json.DefaultJsonProtocol._
 
 
   val route = jobRoute  ~ contextRoute ~ indexRoute
-  startServer("0.0.0.0", webPort) (route)
+  startServer(webIp, webPort) (route)
 
   def indexRoute: Route = pathPrefix("index"){
     get {


### PR DESCRIPTION
Get ip from config is more reasonable then set 0.0.0.0 in the code directly.
Now user can set ip in application.conf like below:

appConf{
	# this ip on which to deploy the apis
	web.services.ip=9.91.12.117
	# the port on which to deploy the apis
	web.services.port=8097
        ...
}