### PR TITLE
ignore dependency-reduced-pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ classpath
 .iml
 .orig
 .java.orig
+dependency-reduced-pom.xml


### PR DESCRIPTION
When I use `mvn package` there would generate a dependency-reduced-pom.xml, to ignore it in git will be nice.