### PR TITLE
1)Add jar manager;2)Add jars when POST job rather than POST context.

### DIFF
--- a/src/main/resources/context_start.sh
+++ b/src/main/resources/context_start.sh
@@ -4,10 +4,10 @@ set -e
 
 dir=`dirname $0`
 parentdir="$(dirname "$dir")"
-classpathParam=$1
-contextName=$2
-port=$3
-xmxMemory=$4
+# classpathParam=$1
+contextName=$1
+port=$2
+xmxMemory=$3
 
 echo "classpathParam = $classpathParam"
 echo "contextName = $contextName"
@@ -76,4 +76,5 @@ export SPARK_HOME
 CLASSPATH="$parentdir/resources:$appdir:$parentdir/spark-job-rest.jar:$($SPARK_HOME/bin/compute-classpath.sh):$classpathParam"
 echo $CLASSPATH
 
-exec java -cp $CLASSPATH $GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $MAIN $conffile $classpathParam $contextName $port >"logs/$2.log" 2>&1
+# exec java -cp $CLASSPATH $GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $MAIN $conffile $classpathParam $contextName $port >"logs/$2.log" 2>&1
+exec java -cp $CLASSPATH $GC_OPTS $JAVA_OPTS $LOGGING_OPTS $CONFIG_OVERRIDES $MAIN $conffile $contextName $port >"logs/$1.log" 2>&1

--- a/src/main/scala/server/Controller.scala
+++ b/src/main/scala/server/Controller.scala
@@ -82,9 +82,9 @@ import spray.json.DefaultJsonProtocol._
           val resultFuture = jarManagerActor ? DeleteJar(jarName)
           respondWithMediaType(MediaTypes.`application/json`) { ctx =>
             resultFuture.map {
-              case Success => ctx.complete(StatusCodes.OK, "Context deleted.")
+              case Success => ctx.complete(StatusCodes.OK, "Jar deleted.")
               case Failure => ctx.complete(StatusCodes.InternalServerError, "Delete jar file failed.")
-              case NoSuchJar => ctx.complete(StatusCodes.BadRequest, "No such context.")
+              case NoSuchJar => ctx.complete(StatusCodes.BadRequest, "No such jar.")
             }
           }
         }

--- a/src/main/scala/server/Controller.scala
+++ b/src/main/scala/server/Controller.scala
@@ -1,20 +1,22 @@
 package server
 
+import java.net.URLDecoder
+
 import akka.actor.{ActorSelection, ActorSystem, ActorRef}
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
 import org.slf4j.LoggerFactory
-import server.domain.actors.{JobActor, ContextManagerActor, ContextActor}
+import server.domain.actors._
 import ContextActor.{FailedInit}
 import ContextManagerActor._
+import JarManagerActor._
 import JobActor._
 import spray.http.{MediaTypes, StatusCodes}
 import spray.routing.{Route, SimpleRoutingApp}
 import akka.pattern.ask
-import server.domain.actors.getValueFromConfig
 
 import scala.concurrent.ExecutionContext
-import scala.util.Success
+import scala.util.{Failure, Success}
 import ExecutionContext.Implicits.global
 import JsonUtils._
 import spray.httpx.SprayJsonSupport.sprayJsonMarshaller
@@ -23,7 +25,7 @@ import spray.json.DefaultJsonProtocol._
 /**
  * Created by raduc on 03/11/14.
  */
-  class Controller(config: Config, contextManagerActor: ActorRef, jobManagerActor: ActorRef, originalSystem: ActorSystem) extends SimpleRoutingApp{
+  class Controller(config: Config, jarManagerActor: ActorRef, contextManagerActor: ActorRef, jobManagerActor: ActorRef, originalSystem: ActorSystem) extends SimpleRoutingApp{
 
   implicit val system = originalSystem
   implicit val timeout = Timeout(60000)
@@ -39,7 +41,7 @@ import spray.json.DefaultJsonProtocol._
   logger.info("Starting web service.")
 
 
-  val route = jobRoute  ~ contextRoute ~ indexRoute
+  val route = jarRoute ~ jobRoute  ~ contextRoute ~ indexRoute
   startServer(webIp, webPort) (route)
 
   def indexRoute: Route = pathPrefix("index"){
@@ -50,39 +52,77 @@ import spray.json.DefaultJsonProtocol._
     }
   }
 
-  def jobRoute: Route = pathPrefix("job"){
-    get{
-        parameters('contextName, 'jobId) { (contextName, jobId) =>
-          respondWithMediaType(MediaTypes.`application/json`) { ctx =>
-            val resultFuture = jobManagerActor ? JobStatusEnquiry(contextName, jobId)
-            resultFuture.map{
-              case x:JobRunSuccess => ctx.complete(StatusCodes.OK, resultToTable("Finished", x.result))
-              case x:JobRunError => ctx.complete(StatusCodes.InternalServerError, resultToTable("Error", x.errorMessage))
-              case x:JobStarted => ctx.complete(StatusCodes.OK, resultToTable("Running", ""))
-              case x:JobDoesNotExist => ctx.complete(StatusCodes.BadRequest, "JobId does not exist!")
-              case NoSuchContext => ctx.complete(StatusCodes.BadRequest, "Context does not exist!")
-              case e:Throwable => ctx.complete(StatusCodes.InternalServerError, e)
-              case x:String => ctx.complete(StatusCodes.InternalServerError, x)
+  def jarRoute: Route = pathPrefix("jar") {
+    post {
+      parameters('jarName, 'storePath, 'replace ? false) { (jarName, storePath, replace) =>
+          entity(as[Array[Byte]]) { jarBytes =>
+            respondWithMediaType(MediaTypes.`application/json`) { ctx =>
+              val resultFuture = jarManagerActor ? AddJar(replace, jarName, storePath, jarBytes)
+              resultFuture.map {
+                case Success => ctx.complete(StatusCodes.OK, "Add jar success.")
+                case JarAlreadyExists => ctx.complete(StatusCodes.BadRequest, "Jar already exists.")
+                case InvalidJar => ctx.complete(StatusCodes.BadRequest, "Jar is not of the right format.")
+                case e: Throwable => ctx.complete(StatusCodes.InternalServerError, e)
+              }
             }
           }
-        }
+      }
     } ~
-    post{
-      parameters('runningClass, 'context ) {
-          (runningClass, context) =>
-        entity(as[String]) { configString =>
-          val config = ConfigFactory.parseString(configString)
+      get {
+        respondWithMediaType(MediaTypes.`application/json`) { ctx =>
+          val resultFuture = jarManagerActor ? GetAllJars()
+          resultFuture.map {
+            case s: String => ctx.complete(StatusCodes.OK, s)
+            case e: Any => ctx.complete(StatusCodes.InternalServerError, e.toString)
+          }
+        }
+      } ~
+      delete {
+        path(Segment) { jarName =>
+          val resultFuture = jarManagerActor ? DeleteJar(jarName)
           respondWithMediaType(MediaTypes.`application/json`) { ctx =>
-            val resultFuture = jobManagerActor ? RunJob(runningClass, context, config)
             resultFuture.map {
-              case x: String => ctx.complete(StatusCodes.OK, x)
-              case e: Error => ctx.complete(StatusCodes.InternalServerError, e)
-              case NoSuchContext => ctx.complete(StatusCodes.BadRequest, "No such context.")
+              case Success => ctx.complete(StatusCodes.OK, "Context deleted.")
+              case Failure => ctx.complete(StatusCodes.InternalServerError, "Delete jar file failed.")
+              case NoSuchJar => ctx.complete(StatusCodes.BadRequest, "No such context.")
             }
           }
         }
       }
-    }
+  }
+
+  def jobRoute: Route = pathPrefix("job") {
+    get {
+      parameters('contextName, 'jobId) { (contextName, jobId) =>
+        respondWithMediaType(MediaTypes.`application/json`) { ctx =>
+          val resultFuture = jobManagerActor ? JobStatusEnquiry(contextName, jobId)
+          resultFuture.map {
+            case x: JobRunSuccess => ctx.complete(StatusCodes.OK, resultToTable("Finished", x.result))
+            case x: JobRunError => ctx.complete(StatusCodes.InternalServerError, resultToTable("Error", x.errorMessage))
+            case x: JobStarted => ctx.complete(StatusCodes.OK, resultToTable("Running", ""))
+            case x: JobDoesNotExist => ctx.complete(StatusCodes.BadRequest, "JobId does not exist!")
+            case NoSuchContext => ctx.complete(StatusCodes.BadRequest, "Context does not exist!")
+            case e: Throwable => ctx.complete(StatusCodes.InternalServerError, e)
+            case x: String => ctx.complete(StatusCodes.InternalServerError, x)
+          }
+        }
+      }
+    } ~
+      post {
+        parameters('runningClass, 'context) { (runningClass, context) =>
+            entity(as[String]) { configString =>
+              val config = ConfigFactory.parseString(URLDecoder.decode(configString, "UTF-8"))
+              respondWithMediaType(MediaTypes.`application/json`) { ctx =>
+                val resultFuture = jobManagerActor ? RunJob(runningClass, context, config)
+                resultFuture.map {
+                  case x: String => ctx.complete(StatusCodes.OK, x)
+                  case e: Error => ctx.complete(StatusCodes.InternalServerError, e)
+                  case NoSuchContext => ctx.complete(StatusCodes.BadRequest, "No such context.")
+                }
+              }
+            }
+        }
+      }
   }
 
     def contextRoute : Route = pathPrefix("context"){
@@ -91,7 +131,7 @@ import spray.json.DefaultJsonProtocol._
         entity(as[String]) { configString =>
           respondWithMediaType(MediaTypes.`application/json`) { ctx =>
 
-          val config = ConfigFactory.parseString(configString)
+          val config = ConfigFactory.parseString(URLDecoder.decode(configString, "UTF-8"))
 
           val resultFuture = contextManagerActor ? CreateContext(contextName, getValueFromConfig(config, "jars", ""), config)
             resultFuture.map {

--- a/src/main/scala/server/Main.scala
+++ b/src/main/scala/server/Main.scala
@@ -23,7 +23,7 @@ object Main {
     val supervisor = system.actorOf(Props(classOf[Supervisor]), "Supervisor")
 
     val jarManagerActor = createActor(Props(new JarManagerActor(defaultConfig)), "JarManager", system, supervisor)
-    val contextManagerActor = createActor(Props(new ContextManagerActor(defaultConfig, jarManagerActor)), "ContextManager", system, supervisor)
+    val contextManagerActor = createActor(Props(new ContextManagerActor(defaultConfig)), "ContextManager", system, supervisor)
     val jobManagerActor = createActor(Props(new JobActor(defaultConfig, jarManagerActor, contextManagerActor)), "JobManager", system, supervisor)
     new Controller(defaultConfig, jarManagerActor, contextManagerActor, jobManagerActor, system)
   }

--- a/src/main/scala/server/Main.scala
+++ b/src/main/scala/server/Main.scala
@@ -1,7 +1,7 @@
 package server
 
 import akka.event.Logging
-import server.domain.actors.{Supervisor, JobActor, ContextManagerActor}
+import server.domain.actors._
 
 import scala.concurrent.Await
 import akka.actor.ActorRef
@@ -9,7 +9,6 @@ import akka.pattern.ask
 
 import akka.actor.{Props, ActorSystem}
 import com.typesafe.config.ConfigFactory
-import server.domain.actors.timeout
 
 /**
  * Created by raduc on 29/10/14.
@@ -23,10 +22,10 @@ object Main {
 
     val supervisor = system.actorOf(Props(classOf[Supervisor]), "Supervisor")
 
-    val contextManagerActor = createActor(Props(new ContextManagerActor(defaultConfig)), "ContextManager", system, supervisor)
+    val jarManagerActor = createActor(Props(new JarManagerActor(defaultConfig)), "JarManager", system, supervisor)
+    val contextManagerActor = createActor(Props(new ContextManagerActor(defaultConfig, jarManagerActor)), "ContextManager", system, supervisor)
     val jobManagerActor = createActor(Props(new JobActor(defaultConfig, contextManagerActor)), "JobManager", system, supervisor)
-    val controller = new Controller(defaultConfig, contextManagerActor, jobManagerActor, system)
-
+    new Controller(defaultConfig, jarManagerActor, contextManagerActor, jobManagerActor, system)
   }
 
   def createActor(props: Props, name: String, customSystem: ActorSystem, supervisor: ActorRef): ActorRef = {

--- a/src/main/scala/server/Main.scala
+++ b/src/main/scala/server/Main.scala
@@ -24,7 +24,7 @@ object Main {
 
     val jarManagerActor = createActor(Props(new JarManagerActor(defaultConfig)), "JarManager", system, supervisor)
     val contextManagerActor = createActor(Props(new ContextManagerActor(defaultConfig, jarManagerActor)), "ContextManager", system, supervisor)
-    val jobManagerActor = createActor(Props(new JobActor(defaultConfig, contextManagerActor)), "JobManager", system, supervisor)
+    val jobManagerActor = createActor(Props(new JobActor(defaultConfig, jarManagerActor, contextManagerActor)), "JobManager", system, supervisor)
     new Controller(defaultConfig, jarManagerActor, contextManagerActor, jobManagerActor, system)
   }
 

--- a/src/main/scala/server/MainContext.scala
+++ b/src/main/scala/server/MainContext.scala
@@ -11,11 +11,11 @@ import server.domain.actors.{Util, ContextActor}
 object MainContext {
 
   def main(args: Array[String]) {
-    //args(0) - appConf , args(1) - jars
+    //args(0) - appConf
     val confFilePath = args(0)
-    val jarsPath = args(1).split(":")
-    val contextName = args(2)
-    val port = args(3).toInt
+    // val jarsPath = args(1).split(":")
+    val contextName = args(1)
+    val port = args(2).toInt
 
     println(s"Started new process for contextName = $contextName with port = $port")
 
@@ -23,7 +23,7 @@ object MainContext {
     val config = Util.remoteConfig("localhost", port, defaultConfig)
     val system = ActorSystem(Util.PREFIX_CONTEXT_SYSTEM + contextName, config)
 
-    system.actorOf(Props(new ContextActor(jarsPath, defaultConfig)), Util.PREFIX_CONTEXT_ACTOR + contextName)
+    system.actorOf(Props(new ContextActor(defaultConfig)), Util.PREFIX_CONTEXT_ACTOR + contextName)
 
     println(s"Initialized system $Util.PREFIX_CONTEXT_SYSTEM$contextName and actor $Util.PREFIX_CONTEXT_SYSTEM$contextName")
 

--- a/src/main/scala/server/domain/actors/ContextActor.scala
+++ b/src/main/scala/server/domain/actors/ContextActor.scala
@@ -1,35 +1,40 @@
 package server.domain.actors
 
-import akka.actor.{Actor, ActorLogging, Terminated}
-import api.{SparkJobValid, SparkJobInvalid, SparkJob}
-import com.typesafe.config.Config
-import org.apache.commons.lang.exception.ExceptionUtils
-import org.apache.spark.SparkContext
-import ContextManagerActor.{DeleteContext, IsAwake}
-import server.domain.actors.JobActor._
-import server.domain.actors.ContextActor._
+import java.net.URL
 
 import scala.collection.mutable.{SynchronizedMap, HashMap}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
+import akka.actor.{Actor, ActorLogging, Terminated}
+import com.typesafe.config.Config
+import org.apache.commons.lang.exception.ExceptionUtils
+import org.apache.log4j.Logger
+import org.apache.spark.SparkContext
+
+import api.{SparkJobValid, SparkJobInvalid, SparkJob}
+import server.domain.actors.ContextActor._
+import server.domain.actors.ContextManagerActor.{DeleteContext, IsAwake}
+import server.domain.actors.JobActor._
+import util.ContextURLClassLoader
+
 /**
  * Created by raduc on 04/11/14.
  */
-
 object ContextActor {
   case class InitializeContext(contextName: String, config: Config)
   case class Initialized()
   case class FailedInit(message: String)
 }
 
-class ContextActor(jarsPath: Array[String], localConfig: Config) extends Actor with ActorLogging{
+class ContextActor(localConfig: Config) extends Actor with ActorLogging{
+
+  private val logger = Logger.getLogger(getClass)
 
   var sparkContext: SparkContext = _
   var defaultConfig: Config = _
   var jobStateMap = new HashMap[String, JobStatus]() with SynchronizedMap[String, JobStatus]
-
 
   startWatchingManagerActor()
 
@@ -40,18 +45,17 @@ class ContextActor(jarsPath: Array[String], localConfig: Config) extends Actor w
     }
 
     case InitializeContext(contextName, config) => {
-
-      println(s"Received InitializeContext message : contextName=$contextName")
-      log.info("Initializing context " + contextName)
+      logger.info(s"Received InitializeContext message : contextName=$contextName")
+      // log.info("Initializing context " + contextName)
 
       try {
 
         defaultConfig = config
-        val sparkConf = configToSparkConf(config,contextName, jarsPath)
+        val sparkConf = configToSparkConf(config,contextName)
         sparkContext = new SparkContext(sparkConf)
 
         sender ! Initialized
-        log.info("Successfully initialized context " + contextName)
+        // log.info("Successfully initialized context " + contextName)
       } catch {
         case e:Exception => {
           e.printStackTrace()
@@ -63,45 +67,52 @@ class ContextActor(jarsPath: Array[String], localConfig: Config) extends Actor w
     }
 
     case DeleteContext(contextName) => {
-      println(s"Received DeleteContext message : contextName=$contextName")
-      log.info("Shutting down SparkContext {}", contextName)
+      logger.info(s"Received DeleteContext message : contextName=$contextName")
+      // log.info("Shutting down SparkContext {}", contextName)
 
       gracefullyShutdown
     }
 
     case job:RunJob => {
-      println(s"Received RunJob message : runningClass=${job.runningClass} contextName=${job.contextName} uuid=${job.uuid} ")
+      logger.info(s"Received RunJob message : runningClass=${job.runningClass} jars=${job.jars} contextName=${job.contextName} uuid=${job.uuid} ")
       jobStateMap += (job.uuid -> JobStarted())
 
+      val jarLoader =  new ContextURLClassLoader(Array[URL](), Thread.currentThread.getContextClassLoader)
+
       Future {
-          val classLoader = Thread.currentThread.getContextClassLoader
-          val runnableClass = classLoader.loadClass(job.runningClass)
-          val sparkJob = runnableClass.newInstance.asInstanceOf[SparkJob]
+        for (jar <- job.jars.split(":")) {
+          sparkContext.addJar(jar) // add jars for remote executors
+          jarLoader.addURL(new URL("file:" + jar)) // add jar to current thread class loader for driver
+        }
 
-          val status = sparkJob.validate(sparkContext, job.config.withFallback(defaultConfig))
-          status match {
-            case SparkJobInvalid(message) => throw new Exception(message)
-            case SparkJobValid() => println("Validation passed.")
-          }
+        val runnableClass = jarLoader.loadClass(job.runningClass)
+        val sparkJob = runnableClass.newInstance.asInstanceOf[SparkJob]
 
-          sparkJob.runJob(sparkContext, job.config.withFallback(defaultConfig))
+        val status = sparkJob.validate(sparkContext, job.config.withFallback(defaultConfig))
+        status match {
+          case SparkJobInvalid(message) => throw new Exception(message)
+          case SparkJobValid() => logger.info("Validation passed.")
+        }
 
+        sparkJob.runJob(sparkContext, job.config.withFallback(defaultConfig))
       } andThen {
         case Success(result) => {
-          println(s"Finished running job : runningClass=${job.runningClass} contextName=${job.contextName} uuid=${job.uuid} ")
+          logger.info(s"Finished running job : runningClass=${job.runningClass} jars=${job.jars} contextName=${job.contextName} uuid=${job.uuid} ")
           jobStateMap += (job.uuid -> JobRunSuccess(result))
+          jarLoader.close()
         }
         case Failure(e:Throwable) => {
           e.printStackTrace()
           jobStateMap += (job.uuid -> JobRunError(ExceptionUtils.getStackTrace(e)))
-          println(s"Error running job : runningClass=${job.runningClass} contextName=${job.contextName} uuid=${job.uuid} ")
+          logger.info(s"Error running job : runningClass=${job.runningClass} jars=${job.jars} contextName=${job.contextName} uuid=${job.uuid} ")
+          jarLoader.close()
         }
       }
     }
     case Terminated(actor) => {
       if(actor.path.toString.contains("Supervisor/ContextManager")){
-        println(s"Received TERMINATED message from: ${actor.path.toString}")
-        println("Shutting down the system because the ManagerSystem terminated.")
+        logger.info(s"Received TERMINATED message from: ${actor.path.toString}")
+        logger.info("Shutting down the system because the ManagerSystem terminated.")
         gracefullyShutdown
       }
     }
@@ -111,7 +122,7 @@ class ContextActor(jarsPath: Array[String], localConfig: Config) extends Actor w
     }
 
     case x @ _ => {
-      println(s"Received UNKNOWN message type $x")
+      logger.info(s"Received UNKNOWN message type $x")
     }
   }
 
@@ -124,12 +135,10 @@ class ContextActor(jarsPath: Array[String], localConfig: Config) extends Actor w
     val managerActor = context.actorSelection(Util.getActorAddress("ManagerSystem", getValueFromConfig(localConfig,"manager.akka.remote.netty.tcp.port", 4042), "Supervisor/ContextManager"))
     managerActor.resolveOne().onComplete {
       case Success(actorRef) => {
-        println(s"Now watching the ContextManager from this actor.")
+        logger.info(s"Now watching the ContextManager from this actor.")
         context.watch(actorRef)
       }
-      case x @ _ => println(s"Received message of type $x")
+      case x @ _ => logger.info(s"Received message of type $x")
     }
   }
 }
-
-

--- a/src/main/scala/server/domain/actors/ContextManagerActor.scala
+++ b/src/main/scala/server/domain/actors/ContextManagerActor.scala
@@ -3,30 +3,26 @@ package server.domain.actors
 import java.io.File
 import java.util
 
+import scala.collection.mutable.{HashMap, SynchronizedMap}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
 import akka.actor.{Actor, ActorLogging, ActorRef, ActorSelection}
 import akka.pattern.ask
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.commons.lang.exception.ExceptionUtils
+import org.apache.log4j.Logger
+
 import server.domain.actors.ContextActor.{FailedInit, InitializeContext, Initialized}
 import server.domain.actors.ContextManagerActor._
-import spray.http.StatusCodes
-
-import scala.collection.mutable.{HashMap, SynchronizedMap}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import scala.util.{Failure, Success}
-
-import server.domain.actors.JarManagerActor.GetJars
 
 /**
  * Created by raduc on 03/11/14.
  */
-
-
 object ContextManagerActor {
 
-  case class CreateContext(contextName: String, jars: String, config: Config)
+  case class CreateContext(contextName: String, config: Config)
   case class ContextInitialized(port: String)
   case class DeleteContext(contextName: String)
   case class GetContext(contextName: String)
@@ -39,6 +35,7 @@ object ContextManagerActor {
 }
 
 class ContextManagerActor(defaultConfig: Config, jarManagerActor: ActorRef) extends Actor with ActorLogging {
+  private val logger = Logger.getLogger(getClass)
 
   var lastUsedPort = getValueFromConfig(defaultConfig, "appConf.actor.systems.first.port", 11000)
   var lastUsedPortSparkUi = getValueFromConfig(defaultConfig, "appConf.spark.ui.first.port", 16000)
@@ -49,12 +46,10 @@ class ContextManagerActor(defaultConfig: Config, jarManagerActor: ActorRef) exte
   val sparkUIConfigPath: String = "spark.ui.port"
 
   override def receive: Receive = {
-    case CreateContext(contextName, jars, config) => {
+    case CreateContext(contextName, config) => {
 
       if(contextMap contains contextName) {
         sender ! ContextAlreadyExists
-      } else if(jars.isEmpty){
-        sender ! FailedInit("jars property is not defined or is empty.")
       } else {
 
         //adding the default configs
@@ -69,27 +64,17 @@ class ContextManagerActor(defaultConfig: Config, jarManagerActor: ActorRef) exte
           mergedConfig = addSparkUiPortToConfig(mergedConfig)
         }
 
-        println(s"Received CreateContext message : context=$contextName jars=$jars")
+        logger.info(s"Received CreateContext message : context=$contextName")
 
-        val isJarsFullPath = getValueFromConfig(mergedConfig, "fullPath", true)
-        if (!isJarsFullPath) {
-          val future = jarManagerActor ? GetJars(jars)
-          future.onSuccess {
-            case fullPathJars: String => doCreate(contextName, fullPathJars, mergedConfig, port, sender)
-            case e @ _     => println(s"Get jars full path cause UNKNOW error. Infor is $e")
-          }
-          future.onFailure {
-            case e => {
-              println(s"An error has occured: ${ExceptionUtils.getStackTrace(e)}")
-            }
-          }
-        } else {
-          doCreate(contextName, jars, mergedConfig, port, sender)
-        }
+        val processBuilder = createProcessBuilder(contextName, port, mergedConfig)
+        processMap += contextName -> processBuilder.start()
+
+        val actorRef = context.actorSelection(Util.getContextActorAddress(contextName, port))
+        sendInitMessage(contextName, port, actorRef, sender, mergedConfig)
       }
     }
       case DeleteContext(contextName) => {
-      println(s"Received DeleteContext message : context=$contextName")
+        logger.info(s"Received DeleteContext message : context=$contextName")
       if (contextMap contains contextName) {
         val contextRef = contextMap remove contextName get
         val processRef = processMap remove contextName get
@@ -105,7 +90,7 @@ class ContextManagerActor(defaultConfig: Config, jarManagerActor: ActorRef) exte
     }
 
     case GetContext(contextName) => {
-      println(s"Received GetContext message : context=$contextName")
+      logger.info(s"Received GetContext message : context=$contextName")
       if (contextMap contains contextName) {
         sender ! contextMap(contextName)
       } else {
@@ -114,18 +99,10 @@ class ContextManagerActor(defaultConfig: Config, jarManagerActor: ActorRef) exte
     }
 
     case GetAllContexts() => {
-      println(s"Received GetAllContexts message.")
+      logger.info(s"Received GetAllContexts message.")
       sender ! contextMap.keys.mkString(",")
     }
 
-  }
-
-  def doCreate(contextName: String, jars: String, mergedConfig: Config, port: Integer, sender: ActorRef) {
-    val processBuilder = createProcessBuilder(contextName, port, jars, mergedConfig)
-    processMap += contextName -> processBuilder.start()
-
-    val actorRef = context.actorSelection(Util.getContextActorAddress(contextName, port))
-    sendInitMessage(contextName, port, actorRef, sender, mergedConfig)
   }
 
   def sendInitMessage(contextName: String, port: Int, actorRef: ActorSelection, sender: ActorRef, config:Config, counter: Int = 1):Unit = {
@@ -138,34 +115,33 @@ class ContextManagerActor(defaultConfig: Config, jarManagerActor: ActorRef) exte
       val futureResult = context.actorOf(ReTry.props(tries = 20, retryTimeOut = 1000 millis, retryInterval = 1500 millis, actorRef)) ? IsAwake
       futureResult.onComplete{
         case Success(value) => {
-          println(s"Got the callback, meaning = $value")
+          logger.info(s"Got the callback, meaning = $value")
 
           val future = actorRef ? InitializeContext(contextName, config)
           future.onComplete {
             case Success(value) => {
-              println(s"Got the callback, meaning = $value")
+              logger.info(s"Got the callback, meaning = $value")
               value match {
                 case Initialized => {
                   contextMap += contextName -> actorRef
                   sender ! ContextInitialized(sparkUiPort)
                 }
                 case e:FailedInit => {
-                  println(s"Init failed for context $contextName");
+                  logger.info(s"Init failed for context $contextName");
                   sender ! e
                   processMap.remove(contextName).foreach(p => scheduleDestroyMessage(p))
                 }
               }
             }
             case Failure(e) => {
-              println("FAILED to send init message!")
-              e.printStackTrace
-                sender ! FailedInit(ExceptionUtils.getStackTrace(e))
-                processMap.remove(contextName).get.destroy
+              logger.error("FAILED to send init message!", e)
+              sender ! FailedInit(ExceptionUtils.getStackTrace(e))
+              processMap.remove(contextName).get.destroy
             }
           }
         }
         case Failure(e) => {
-          println("FAILED to send IsAwake message, the new Actor didn't initialize!")
+          logger.info("FAILED to send IsAwake message, the new Actor didn't initialize!")
         }
       }
     }
@@ -179,13 +155,13 @@ class ContextManagerActor(defaultConfig: Config, jarManagerActor: ActorRef) exte
     newConf.withFallback(config)
   }
 
-  def createProcessBuilder(contextName: String, port: Int, jars: String, config: Config): ProcessBuilder = {
+  def createProcessBuilder(contextName: String, port: Int, config: Config): ProcessBuilder = {
 
     val scriptPath = ContextManagerActor.getClass.getClassLoader.getResource("context_start.sh").getPath
 
     val xmxMemory = getValueFromConfig(config, "driver.xmxMemory", "1g")
 
-    val pb = new ProcessBuilder(scriptPath, jars, contextName, port.toString, xmxMemory)
+    val pb = new ProcessBuilder(scriptPath, contextName, port.toString, xmxMemory)
     pb.redirectErrorStream(true)
     pb.redirectOutput(new File("logs/" + contextName + "-initializer.log"))
   }

--- a/src/main/scala/server/domain/actors/ContextManagerActor.scala
+++ b/src/main/scala/server/domain/actors/ContextManagerActor.scala
@@ -34,7 +34,7 @@ object ContextManagerActor {
 
 }
 
-class ContextManagerActor(defaultConfig: Config, jarManagerActor: ActorRef) extends Actor with ActorLogging {
+class ContextManagerActor(defaultConfig: Config) extends Actor with ActorLogging {
   private val logger = Logger.getLogger(getClass)
 
   var lastUsedPort = getValueFromConfig(defaultConfig, "appConf.actor.systems.first.port", 11000)

--- a/src/main/scala/server/domain/actors/JarManagerActor.scala
+++ b/src/main/scala/server/domain/actors/JarManagerActor.scala
@@ -1,0 +1,89 @@
+package server.domain.actors
+
+import java.io.{ BufferedOutputStream, File, FileOutputStream }
+
+import scala.collection.mutable.{ HashMap, SynchronizedMap }
+import scala.util.{ Failure, Success }
+
+import akka.actor.{ Actor, ActorLogging }
+import com.typesafe.config.Config
+
+import server.domain.actors.JarManagerActor._
+
+object JarManagerActor {
+  case class AddJar(replace: Boolean, jarName: String, storePath: String, jarBytes: Array[Byte])
+  case class DeleteJar(jarName: String)
+  case class GetJars(jarNames: String)
+  case class GetAllJars()
+  case class NoSuchJar()
+  case class JarAlreadyExists()
+  case class InvalidJar()
+}
+
+class JarManagerActor(config: Config) extends Actor with ActorLogging {
+
+  val jarMap = new HashMap[String, String]() with SynchronizedMap[String, String]
+
+  override def receive: Receive = {
+
+    case AddJar(replace, jarName, storePath, jarBytes) => {
+      println(s"Received AddJar message : jarName=$jarName storePath=$storePath bytes=" + jarBytes.size)
+      if (jarMap.contains(jarName) && !replace) {
+        sender ! JarAlreadyExists
+      } else if (!validateJarBytes(jarBytes)) {
+        sender ! InvalidJar
+      } else {
+        val outFile = new File(storePath, jarName + ".jar")
+        val buffOutStream = new BufferedOutputStream(new FileOutputStream(outFile))
+        try {
+          buffOutStream.write(jarBytes)
+          buffOutStream.flush
+          jarMap.put(jarName, outFile.getAbsolutePath)
+        } finally {
+          buffOutStream.close
+        }
+        sender ! Success
+      }
+    }
+
+    case DeleteJar(jarName) => {
+      println(s"Received DeleteJar message : jarName=$jarName")
+      if (jarMap.contains(jarName)) {
+        val storePath = jarMap.remove(jarName).get
+        val jarFile = new File(storePath)
+        if (jarFile.delete) {
+          sender ! Success
+        } else {
+          sender ! Failure
+        }
+      } else {
+        sender ! NoSuchJar
+      }
+    }
+
+    case GetJars(jarNames) => {
+      import scala.collection.mutable.ArrayBuffer
+      println(s"Received GetJars message : jarNames=$jarNames")
+      val jarNameArr = jarNames.split(":")
+      val arrBuff = new ArrayBuffer[String]
+      for (jarName <- jarNameArr) {
+        jarMap.get(jarName) match {
+          case Some(s) => arrBuff.+=(s)
+          case None    => println(s"$jarName did not add.")
+        }
+      }
+      sender ! arrBuff.toArray[String].mkString(":")
+    }
+
+    case GetAllJars() => {
+      println(s"Received GetAllJars message.")
+      sender ! jarMap.values.mkString(",")
+    }
+  }
+
+  def validateJarBytes(jarBytes: Array[Byte]): Boolean = {
+    jarBytes.size > 4 &&
+      // For now just check the first few bytes are the ZIP signature: 0x04034b50 little endian
+      jarBytes(0) == 0x50 && jarBytes(1) == 0x4b && jarBytes(2) == 0x03 && jarBytes(3) == 0x04
+  }
+}

--- a/src/main/scala/server/domain/actors/JobActor.scala
+++ b/src/main/scala/server/domain/actors/JobActor.scala
@@ -2,72 +2,70 @@ package server.domain.actors
 
 import java.util.UUID
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 import akka.actor.{Actor, ActorLogging, ActorRef, ActorSelection}
 import akka.pattern.ask
 import com.typesafe.config.Config
 import org.apache.commons.lang.exception.ExceptionUtils
+import org.apache.log4j.Logger
+
 import server.domain.actors.ContextManagerActor.{GetContext, NoSuchContext}
+import server.domain.actors.JarManagerActor.GetJars
 import server.domain.actors.JobActor._
-import scala.concurrent.ExecutionContext.Implicits.global
+
 /**
  * Created by raduc on 03/11/14.
  */
-
-
 object JobActor {
 
   trait JobStatus
 
   case class JobStatusEnquiry(contextName: String, jobId: String)
-
-  case class RunJob(runningClass: String, contextName: String, config: Config, uuid: String = UUID.randomUUID().toString)
-
+  case class RunJob(runningClass: String, jars: String, contextName: String, config: Config, uuid: String = UUID.randomUUID().toString)
   case class JobRunError(errorMessage: String) extends JobStatus
-
   case class JobRunSuccess(result:Any) extends JobStatus
-
   case class JobStarted() extends JobStatus
-
   case class JobDoesNotExist() extends JobStatus
-
   case class UpdateJobStatus(uuid: String, status: JobStatus)
 
 }
 
 
-class JobActor(config: Config, contextManagerActor: ActorRef) extends Actor with ActorLogging {
+class JobActor(config: Config, jarManagerActor: ActorRef, contextManagerActor: ActorRef) extends Actor with ActorLogging {
+  private val logger = Logger.getLogger(getClass)
 
   override def receive: Receive = {
     case job: RunJob => {
-      println(s"Received RunJob message : runningClass=${job.runningClass} context=${job.contextName} uuid=${job.uuid}")
+      logger.info(s"Received RunJob message : runningClass=${job.runningClass} jars=${job.jars} context=${job.contextName} uuid=${job.uuid}")
 
       val fromWebApi = sender
 
-      val future = contextManagerActor ? GetContext(job.contextName)
-      future onSuccess {
-        case contextRef: ActorSelection => {
-
-          fromWebApi ! job.uuid
-
-          println(s"Sending RunJob message to actor $contextRef")
-          contextRef ! job
-        }
-        case NoSuchContext => fromWebApi ! NoSuchContext
-        case e @ _ => println(s"Received UNKNOWN TYPE when asked for context. Type received $e")
-      }
-      future onFailure  {
-        case e => {
-          fromWebApi ! e
-          println(s"An error has occured: ${ExceptionUtils.getStackTrace(e)}")
+      if (job.jars.isEmpty) {
+        fromWebApi ! JobRunError("jars property is not defined or is empty.")
+      } else {
+        val isJarsFullPath = getValueFromConfig(job.config, "fullPath", true)
+        if (!isJarsFullPath) {
+          val future = jarManagerActor ? GetJars(job.jars)
+          future.onSuccess {
+            case fullPathJars: String => runJob(RunJob(job.runningClass, fullPathJars, job.contextName, job.config, job.uuid), fromWebApi)
+            case e @ _ => logger.error(s"Get jars full path cause UNKNOW error. Infor is $e")
+          }
+          future.onFailure {
+            case e => {
+              logger.error(s"An error has occured: ${ExceptionUtils.getStackTrace(e)}")
+            }
+          }
+        } else {
+          runJob(job, fromWebApi)
         }
       }
     }
 
 
     case jobEnquiry:JobStatusEnquiry => {
-      println(s"Received JobStatusEnquiry message : uuid=${jobEnquiry.jobId}")
+      logger.info(s"Received JobStatusEnquiry message : uuid=${jobEnquiry.jobId}")
       val fromWebApi = sender
-
 
       val contextActorFuture = contextManagerActor ? GetContext(jobEnquiry.contextName)
 
@@ -78,11 +76,11 @@ class JobActor(config: Config, contextManagerActor: ActorRef) extends Actor with
 
           enquiryFuture onSuccess{
             case state:JobStatus => {
-              println("Job with id: " + jobEnquiry.jobId + "  has state : " + state)
+              logger.info("Job with id: " + jobEnquiry.jobId + "  has state : " + state)
               fromWebApi ! state
             }
             case x:Any => {
-              println(s"Received $x TYPE when asked for job enquiry.")
+              logger.info(s"Received $x TYPE when asked for job enquiry.")
               fromWebApi ! x
             }
           }
@@ -90,22 +88,42 @@ class JobActor(config: Config, contextManagerActor: ActorRef) extends Actor with
           enquiryFuture onFailure{
             case e => {
               fromWebApi ! e
-              println(s"An error has occured: ${ExceptionUtils.getStackTrace(e)}")
+              logger.error(s"An error has occured: ${ExceptionUtils.getStackTrace(e)}")
             }
           }
         }
         case NoSuchContext => fromWebApi ! NoSuchContext
-        case e @ _ => println(s"Received UNKNOWN TYPE when asked for context. Type received $e")
+        case e @ _ => logger.error(s"Received UNKNOWN TYPE when asked for context. Type received $e")
       }
 
       contextActorFuture onFailure  {
         case e => {
           fromWebApi ! e
-          println(s"An error has occured: ${ExceptionUtils.getStackTrace(e)}")
+          logger.error(s"An error has occured: ${ExceptionUtils.getStackTrace(e)}")
         }
       }
     }
+  }
 
+  def runJob(job: RunJob, fromWebApi: ActorRef){
+    val future = contextManagerActor ? GetContext(job.contextName)
+    future onSuccess {
+      case contextRef: ActorSelection => {
+
+        fromWebApi ! job.uuid
+
+        logger.info(s"Sending RunJob message to actor $contextRef")
+        contextRef ! job
+      }
+      case NoSuchContext => fromWebApi ! NoSuchContext
+      case e @ _ => logger.error(s"Received UNKNOWN TYPE when asked for context. Type received $e")
+    }
+    future onFailure  {
+      case e => {
+        fromWebApi ! e
+        logger.error(s"An error has occured: ${ExceptionUtils.getStackTrace(e)}")
+      }
+    }
   }
 }
 

--- a/src/main/scala/server/domain/actors/ReTry.scala
+++ b/src/main/scala/server/domain/actors/ReTry.scala
@@ -1,15 +1,14 @@
 package server.domain.actors
 
-import akka.actor._
-import akka.pattern.ask
-
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
+
+import akka.actor._
+import akka.pattern.ask
 
 /*
  See http://www.codetinkerhack.com/2014/01/re-try-pattern-using-akka-actor-ask.html
  */
-
 object ReTry {
   private case class Retry(originalSender: ActorRef, message: Any, times: Int)
 

--- a/src/main/scala/server/domain/actors/Supervisor.scala
+++ b/src/main/scala/server/domain/actors/Supervisor.scala
@@ -1,10 +1,9 @@
 package server.domain.actors
 
+import scala.concurrent.duration._
+
 import akka.actor.SupervisorStrategy._
 import akka.actor.{Actor, OneForOneStrategy, Props, actorRef2Scala}
-
-import scala.concurrent.duration._
- 
 
 class Supervisor extends Actor {
 

--- a/src/main/scala/server/domain/actors/package.scala
+++ b/src/main/scala/server/domain/actors/package.scala
@@ -1,10 +1,10 @@
 package server.domain
 
+import scala.collection.JavaConverters._
+
 import akka.util.Timeout
 import com.typesafe.config.Config
 import org.apache.spark.SparkConf
-
-import scala.collection.JavaConverters._
 
 /**
  * Created by raduc on 13/11/14.
@@ -12,14 +12,21 @@ import scala.collection.JavaConverters._
 package object actors {
   implicit val timeout = Timeout(50000)
 
-  def getValueFromConfig[T](config: Config, configPath: String, defaultValue: T): T ={
+  def getValueFromConfig[T](config: Config, configPath: String, defaultValue: T): T = {
     return if (config.hasPath(configPath)) config.getAnyRef(configPath).asInstanceOf[T] else defaultValue
   }
 
-  def configToSparkConf(config:Config, contextName:String, jars: Array[String]): SparkConf ={
+  def configToSparkConf(config: Config, contextName: String, jars: Array[String]): SparkConf = {
     val sparkConf = new SparkConf().setAppName(contextName).setJars(jars)
-    for(x <- config.entrySet().asScala
-      if(x.getKey.startsWith("spark."))){
+    for (x <- config.entrySet().asScala if (x.getKey.startsWith("spark."))) {
+      sparkConf.set(x.getKey, x.getValue.unwrapped().toString)
+    }
+    sparkConf
+  }
+
+  def configToSparkConf(config: Config, contextName: String): SparkConf = {
+    val sparkConf = new SparkConf().setAppName(contextName)
+    for (x <- config.entrySet().asScala if (x.getKey.startsWith("spark."))) {
       sparkConf.set(x.getKey, x.getValue.unwrapped().toString)
     }
     sparkConf

--- a/src/main/scala/util/ContextURLClassLoader.scala
+++ b/src/main/scala/util/ContextURLClassLoader.scala
@@ -1,0 +1,21 @@
+package util
+
+import java.net.{URLClassLoader, URL}
+import org.slf4j.LoggerFactory
+
+/**
+ * The addURL method in URLClassLoader is protected. We subclass it to make this accessible.
+ * NOTE: This is copied from Spark's ExecutorURLClassLoader, which is private[spark].
+ */
+class ContextURLClassLoader(urls: Array[URL], parent: ClassLoader)
+  extends URLClassLoader(urls, parent) {
+
+  val logger = LoggerFactory.getLogger(getClass)
+
+  override def addURL(url: URL) {
+    if (!getURLs.contains(url)) {
+      super.addURL(url)
+      logger.info("Added URL " + url + " to ContextURLClassLoader")
+    }
+  }
+}


### PR DESCRIPTION
1. User can sent jar to server from local by RESTful API, and in server will store this jar.
Usages:
POST /jar/?jarName={jarName}&storePath={storePathInServer}&replace={true/false} (PS: replace has default value true, means will replace the old jar with same jarName, it is a option parameter)
GET /jar (PS: get all jars store in server)
DELETE /jar/{jarName}

2. For create context, user can create as before or use jars name in new way.
For example:
POST /context/{contextName}
jars="appJarName:dependenceJarName" (PS: need add appJarName and dependenceJarName before)
fullPath=false
In this way will get jars full path auto use jars name