### PR TITLE
#24 - Implement SparkContext & SQLContext factories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dependency-reduced-pom.xml
 **/resources/deploy-settings.sh
 # TODO: Implement basic fairscheduler config
 **/resources/fairscheduler.xml
+metastore_db

--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,11 @@ remote-log:
 	@$(REMOTE_PARAMS) $(CURRENT_DIR)/spark-job-rest/src/main/scripts/deploy.sh log
 
 start:
-	@echo "Starting spark-job-REST..."; \
-	cd $(SJR_DEPLOY_PATH); \
-	bin/start_server.sh
+	@SJR_DEPLOY_PATH=$(SJR_DEPLOY_PATH) \
+    $(CURRENT_DIR)/spark-job-rest/src/main/scripts/deploy.sh start
 
 stop:
-	@echo "Stopping spark-job-REST..."; \
-	cd $(SJR_DEPLOY_PATH); \
-	bin/stop_server.sh
+	@SJR_DEPLOY_PATH=$(SJR_DEPLOY_PATH) \
+    $(CURRENT_DIR)/spark-job-rest/src/main/scripts/deploy.sh stop
 
 .PHONY: all build deploy

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ GC_OPTS="${GC_OPTS}
 
 ## Custom contexts
 
-Spark-Job-REST supports custom job context factories defined in `context.job-context-factory`.
+Spark-Job-REST supports custom job context factories defined in `context.job-context-factory` property of config.
 By default SJR uses `context.SparkContextFactory` which creates one Spark Context per JVM.
 
 ### SQL contexts

--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ GC_OPTS="${GC_OPTS}
          ${YOUR_EXTRA_GC_OPTIONS}"           
 ```
 
+## Custom contexts
+
+Spark-Job-REST supports custom job context factories defined in `context.job-context-factory`.
+By default SJR uses `context.SparkContextFactory` which creates one Spark Context per JVM.
+
+### SQL contexts
+
+To run jobs with provided SQL contexts include `spark-job-rest-sql` in your project, set context factory to one of SQLContext factories provided by this library and inherit your job from `api.SparkSqlJob`.
+Currently supported contexts:
+
+1. `context.SparkSqlContextFactory` creates simple job SQLContext.
+2. `context.HiveContextFactory` creates Hive SQL context.
+
 ## Configure Spark environment
 
 In order to have a proper installation you should set `$SPARK_HOME` to your Apache Spark distribution and `$SPARK_CONF_HOME` to directory which consists `spark-env.sh` (usually `$SPARK_HOME/conf` or `$SPARK_HOME/libexec/conf`).

--- a/examples/s3-download-job/pom.xml
+++ b/examples/s3-download-job/pom.xml
@@ -37,21 +37,25 @@
             <artifactId>httpclient</artifactId>
             <version>4.3.4</version>
         </dependency>
+		
         <dependency>
             <groupId>com.xpatterns</groupId>
             <artifactId>spark-job-rest-api</artifactId>
-            <version>0.3.1-spark1.3.1</version>
+            <version>0.3.2</version>
         </dependency>
+		
         <dependency>
             <groupId>com.xpatterns</groupId>
             <artifactId>spark-job-rest-client</artifactId>
             <version>0.3.1</version>
         </dependency>
+
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
             <version>1.8.3</version>
         </dependency>
+		
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.10</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.xpatterns</groupId>
 	<artifactId>spark-job-REST</artifactId>
-	<version>0.3.0</version>
+	<version>0.3.2</version>
 	<packaging>pom</packaging>
 
 	<name>spark-job-REST</name>
@@ -12,6 +12,7 @@
 
 	<modules>
 		<module>spark-job-rest-api</module>
+		<module>spark-job-rest-sql</module>
 		<module>spark-job-rest</module>
         <module>spark-job-rest-client</module>
 		<module>examples/example-job</module>

--- a/spark-job-rest-api/pom.xml
+++ b/spark-job-rest-api/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.xpatterns</groupId>
 	<artifactId>spark-job-rest-api</artifactId>
-	<version>0.3.1</version>
+	<version>0.3.2</version>
 	<packaging>jar</packaging>
 
 	<name>spark-job-rest-api</name>
@@ -13,12 +13,14 @@
     <description>The API for Spark-Job-Rest.
         Contains the SparkJob interface that must be extended in order to run jobs on the server.
     </description>
+
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
+
     <developers>
         <developer>
             <name>Radu Chilom</name>
@@ -27,6 +29,7 @@
             <organizationUrl>http://www.atigeo.com</organizationUrl>
         </developer>
     </developers>
+
     <scm>
         <connection>scm:git:git@github.com:Atigeo/spark-job-rest.git</connection>
         <developerConnection>scm:git:git@github.com:Atigeo/spark-job-rest.git</developerConnection>
@@ -58,6 +61,7 @@
             <url>https://repository.cloudera.com/artifactory/repo/</url>
         </repository>
 	</repositories>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<scala.version>2.10.3</scala.version>
@@ -77,7 +81,6 @@
             <version>1.2.6</version>
         </dependency>
 	</dependencies>
-
 
     <build>
         <resources>
@@ -129,9 +132,7 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
-
     </build>
 
     <profiles>

--- a/spark-job-rest-api/src/main/scala/api/ContextLike.scala
+++ b/spark-job-rest-api/src/main/scala/api/ContextLike.scala
@@ -1,0 +1,44 @@
+package api
+
+import org.apache.spark.SparkContext
+
+trait ContextLike {
+  /**
+   * Type of the context for representation
+   */
+  val contextClass: String
+
+  override def toString: String = {
+    super.toString + s"($contextClass)"
+  }
+
+  /**
+   * Underlying Spark context
+   * @return
+   */
+  def sparkContext: SparkContext
+
+  /**
+   * Validates whether job is valid for this context
+   * @param job job to validate
+   * @return
+   */
+  def validateJob(job: SparkJobBase): SparkJobValidation =
+    if (isValidJob(job))
+      SparkJobValid()
+    else
+      SparkJobInvalid(s"Job ${job.toString} doesn't match context $this.")
+
+  /**
+   * Validates whether job is valid for this context
+   * Should be implemented in concrete classes.
+   * @param job job to validate
+   * @return
+   */
+  def isValidJob(job: SparkJobBase): Boolean
+
+  /**
+   * This method should be called during cleanup
+   */
+  def stop()
+}

--- a/spark-job-rest-api/src/main/scala/api/SparkJob.scala
+++ b/spark-job-rest-api/src/main/scala/api/SparkJob.scala
@@ -17,7 +17,8 @@ case class SparkJobInvalid(reason: String) extends SparkJobValidation
 /**
  *  This trait is the main API for Spark jobs submitted to the Job Server.
  */
-trait SparkJob {
+trait SparkJobBase {
+  type C
   /**
    * This is the entry point for a Spark Job Server to execute Spark jobs.
    * This function should create or reuse RDDs and return the result at the end, which the
@@ -26,7 +27,7 @@ trait SparkJob {
    * @param jobConfig the Typesafe Config object passed into the job request
    * @return the job result
    */
-  def runJob(sc: SparkContext, jobConfig: Config): Any
+  def runJob(sc: C, jobConfig: Config): Any
 
   /**
    * This method is called by the job server to allow jobs to validate their input and reject
@@ -36,5 +37,9 @@ trait SparkJob {
    * trying to start this job.
    * @return either SparkJobValid or SparkJobInvalid
    */
-  def validate(sc: SparkContext, config: Config): SparkJobValidation
+  def validate(sc: C, config: Config): SparkJobValidation
+}
+
+trait SparkJob extends SparkJobBase {
+  type C = SparkContext
 }

--- a/spark-job-rest-api/src/main/scala/responses/JobStates.scala
+++ b/spark-job-rest-api/src/main/scala/responses/JobStates.scala
@@ -1,9 +1,8 @@
 package responses
 
 /**
- * Created by raduchilom on 4/24/15.
+ * States of Spark jobs.
  */
-
 object JobStates {
 
   sealed abstract class JobState(val name: String) {
@@ -15,5 +14,7 @@ object JobStates {
   case object ERROR extends JobState("Error")
 
   case object FINISHED extends JobState("Finished")
+
+  case object QUEUED extends JobState("Queued")
 
 }

--- a/spark-job-rest-client/pom.xml
+++ b/spark-job-rest-client/pom.xml
@@ -4,20 +4,21 @@
 
 	<groupId>com.xpatterns</groupId>
 	<artifactId>spark-job-rest-client</artifactId>
-	<version>0.3.1</version>
+	<version>0.3.2</version>
 	<packaging>jar</packaging>
 
 	<name>spark-job-rest-client</name>
 	<url>https://github.com/Atigeo/spark-job-rest</url>
 
-    <description>The Http Spray Client for Spark-Job-Rest.
-    </description>
+    <description>The Http Spray Client for Spark-Job-Rest.</description>
+
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
+
     <developers>
         <developer>
             <name>Radu Chilom</name>
@@ -26,6 +27,7 @@
             <organizationUrl>http://www.atigeo.com</organizationUrl>
         </developer>
     </developers>
+
     <scm>
         <connection>scm:git:git@github.com:Atigeo/spark-job-rest.git</connection>
         <developerConnection>scm:git:git@github.com:Atigeo/spark-job-rest.git</developerConnection>
@@ -57,6 +59,7 @@
             <url>https://repository.cloudera.com/artifactory/repo/</url>
         </repository>
 	</repositories>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<scala.version>2.10.3</scala.version>
@@ -82,7 +85,7 @@
         <dependency>
             <groupId>com.xpatterns</groupId>
             <artifactId>spark-job-rest-api</artifactId>
-            <version>0.3.1</version>
+            <version>${version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/spark-job-rest-sql/pom.xml
+++ b/spark-job-rest-sql/pom.xml
@@ -3,11 +3,11 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.xpatterns</groupId>
-	<artifactId>example-job</artifactId>
-	<version>1.0.0</version>
+	<artifactId>spark-job-rest-sql</artifactId>
+	<version>0.3.2</version>
 	<packaging>jar</packaging>
 
-	<name>example-job</name>
+	<name>spark-job-rest-sql</name>
 	<url>http://maven.apache.org</url>
 
 	<repositories>
@@ -23,6 +23,7 @@
 			<id>Akka repository</id>
 			<url>http://repo.akka.io/releases</url>
 		</repository>
+
 	</repositories>
 
 	<properties>
@@ -33,17 +34,61 @@
 
 	<dependencies>
         <dependency>
-            <groupId>com.xpatterns</groupId>
-            <artifactId>spark-job-rest-api</artifactId>
-            <version>0.3.2</version>
-        </dependency>
-
-		<dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.10</artifactId>
             <version>1.3.1</version>
             <scope>provided</scope>
         </dependency>
+
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-hive_2.10</artifactId>
+			<version>1.3.1</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-sql_2.10</artifactId>
+			<version>1.3.1</version>
+			<scope>provided</scope>
+		</dependency>
+
+        <dependency>
+            <groupId>com.xpatterns</groupId>
+            <artifactId>spark-job-rest-api</artifactId>
+            <version>${version}</version>
+			<scope>provided</scope>
+        </dependency>
+
+		<dependency>
+			<groupId>com.xpatterns</groupId>
+			<artifactId>spark-job-rest</artifactId>
+			<version>${version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.typesafe</groupId>
+			<artifactId>config</artifactId>
+			<version>1.2.1</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.4</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scalatest</groupId>
+			<artifactId>scalatest_2.10</artifactId>
+			<version>2.2.4</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -56,38 +101,21 @@
 				<filtering>false</filtering>
 			</resource>
 		</resources>
-
 		<finalName>${project.artifactId}</finalName>
-
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.scala-tools</groupId>
-					<artifactId>maven-scala-plugin</artifactId>
-					<version>2.9.1</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.0.2</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<!-- <version>3.1</version> -->
+				<version>3.1</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>
 				</configuration>
 			</plugin>
-
 			<plugin>
-				<groupId>org.scala-tools</groupId>
-				<artifactId>maven-scala-plugin</artifactId>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<id>scala-compile-first</id>
@@ -104,11 +132,16 @@
 							<goal>testCompile</goal>
 						</goals>
 					</execution>
+					<execution>
+						<id>doc</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>doc-jar</goal>
+						</goals>
+					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
-
 	</build>
 
 </project>

--- a/spark-job-rest-sql/src/main/scala/api/SparkSqlJob.scala
+++ b/spark-job-rest-sql/src/main/scala/api/SparkSqlJob.scala
@@ -1,0 +1,7 @@
+package api
+
+import org.apache.spark.sql.SQLContext
+
+trait SparkSqlJob extends SparkJobBase {
+  type C = SQLContext
+}

--- a/spark-job-rest-sql/src/main/scala/context/HiveContextFactory.scala
+++ b/spark-job-rest-sql/src/main/scala/context/HiveContextFactory.scala
@@ -1,0 +1,24 @@
+package context
+
+import api.{ContextLike, SparkJobBase, SparkSqlJob}
+import com.typesafe.config.Config
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.hive.HiveContext
+import org.slf4j.LoggerFactory
+
+/**
+ * Factory which creates Hive context.
+ */
+class HiveContextFactory extends SQLContextFactory {
+  type C = HiveContext with ContextLike
+  val logger = LoggerFactory.getLogger(getClass)
+
+  def makeContext(config: Config, sc: SparkContext): C = {
+    logger.info(s"Creating Hive context for Spark context $sc.")
+    new HiveContext(sc) with ContextLike {
+      val contextClass = classOf[HiveContext].getName
+      def isValidJob(job: SparkJobBase) = job.isInstanceOf[SparkSqlJob]
+      def stop() = sparkContext.stop()
+    }
+  }
+}

--- a/spark-job-rest-sql/src/main/scala/context/SQLContextFactory.scala
+++ b/spark-job-rest-sql/src/main/scala/context/SQLContextFactory.scala
@@ -1,0 +1,47 @@
+package context
+
+import com.typesafe.config.Config
+import org.apache.spark.SparkContext
+
+import scala.util.Try
+
+trait SQLContextFactory extends JobContextFactory {
+  /**
+   * Creates Spark context from class specified under [[SQLContextFactory.sparkContextFactoryClassNameConfigEntry]]
+   * config entry or from [[JobContextFactory.defaultFactoryClassName]]
+   * @param config general configuration
+   * @param contextName context name
+   * @return
+   */
+  def makeContext(config: Config, contextName: String): C = {
+    val sparkContext = getSparkContextFactory(config)
+      .makeContext(config: Config, contextName: String)
+      .asInstanceOf[SparkContext]
+    makeContext(config, sparkContext)
+  }
+
+  /**
+   * Creates SQL context for specified Spark context.
+   * Should be implemented by concrete SQL context factory
+   * @param config general configuration
+   * @param sparkContext underlying Spark context
+   * @return
+   */
+  def makeContext(config: Config, sparkContext: SparkContext): C
+
+  /**
+   * Loads factory for Spark context.
+   * @param config general configuration as in [[JobContextFactory.getFactory()]]
+   * @return
+   */
+  def getSparkContextFactory(config: Config): JobContextFactory = {
+    val className = Try {
+      config.getString(SQLContextFactory.sparkContextFactoryClassNameConfigEntry)
+    }.getOrElse(JobContextFactory.defaultFactoryClassName)
+    JobContextFactory.getFactory(className)
+  }
+}
+
+object SQLContextFactory {
+  val sparkContextFactoryClassNameConfigEntry = "context.spark-context-factory"
+}

--- a/spark-job-rest-sql/src/main/scala/context/SparkSQLContextFactory.scala
+++ b/spark-job-rest-sql/src/main/scala/context/SparkSQLContextFactory.scala
@@ -1,0 +1,24 @@
+package context
+
+import api.{ContextLike, SparkJobBase, SparkSqlJob}
+import com.typesafe.config.Config
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
+import org.slf4j.LoggerFactory
+
+/**
+ * Factory which creates simple SQL context.
+ */
+class SparkSQLContextFactory extends SQLContextFactory {
+  type C = SQLContext with ContextLike
+  val logger = LoggerFactory.getLogger(getClass)
+
+  def makeContext(config: Config, sc: SparkContext): C = {
+    logger.info(s"Creating SQL context for Spark context $sc.")
+    new SQLContext(sc) with ContextLike {
+      val contextClass = classOf[SQLContext].getName
+      def isValidJob(job: SparkJobBase) = job.isInstanceOf[SparkSqlJob]
+      def stop() = sparkContext.stop()
+    }
+  }
+}

--- a/spark-job-rest-sql/src/test/scala/context/HiveContextFactorySpec.scala
+++ b/spark-job-rest-sql/src/test/scala/context/HiveContextFactorySpec.scala
@@ -1,0 +1,49 @@
+package context
+
+import api.ContextLike
+import com.typesafe.config.ConfigFactory
+import org.apache.spark.sql.hive.HiveContext
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.Try
+
+/**
+ * Test suite for [[HiveContextFactory]].
+ */
+@RunWith(classOf[JUnitRunner])
+class HiveContextFactorySpec extends WordSpec with MustMatchers with BeforeAndAfter {
+  type C = HiveContext with ContextLike
+  
+  var hiveContext: C = _
+  
+  val hiveContextFactory = new HiveContextFactory()
+  
+  // Clean Spark context after each test
+  after {
+    Try{ hiveContext.stop() }
+  }
+
+  "HiveContextFactory" should {
+    "create Hive context" in {
+      hiveContext = hiveContextFactory.makeContext(config, this.getClass.getName)
+      hiveContext.sparkContext.appName mustEqual this.getClass.getName
+    }
+
+    "stop underlying Spark context if context is stopped" in {
+      hiveContext = hiveContextFactory.makeContext(config, "context1")
+      hiveContext.stop()
+      hiveContext = hiveContextFactory.makeContext(config, "context2")
+      hiveContext.sparkContext.appName mustEqual "context2"
+    }
+  }
+
+  val config = ConfigFactory.parseString(
+    """
+      |{
+      |  context.jars = [],
+      |  spark.master = "local"
+      |}
+    """.stripMargin)
+}

--- a/spark-job-rest-sql/src/test/scala/context/SQLContextFactorySpec.scala
+++ b/spark-job-rest-sql/src/test/scala/context/SQLContextFactorySpec.scala
@@ -1,0 +1,79 @@
+package context
+
+import api.{ContextLike, SparkJobBase}
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.hive.HiveContext
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+import utils.ContextUtils.configToSparkConf
+
+import scala.util.Try
+
+trait FakeContext
+
+class FakeJobContextFactory extends JobContextFactory {
+  type C = ContextLike
+  def makeContext(config: Config, contextName: String): ContextLike = {
+    val sparkConf = configToSparkConf(config, contextName)
+    new SparkContext(sparkConf) with ContextLike with FakeContext {
+      val contextClass = classOf[FakeContext].getName
+      override def isValidJob(job: SparkJobBase): Boolean = true
+      override def sparkContext: SparkContext = this
+    }
+  }
+}
+
+/**
+ * Test suite for [[SQLContextFactory]].
+ */
+@RunWith(classOf[JUnitRunner])
+class SQLContextFactorySpec extends WordSpec with MustMatchers with BeforeAndAfter {
+  type C <: ContextLike
+  
+  var sqlContext: C = _
+  
+  // Clean up Spark context after each test
+  after {
+    Try{ sqlContext.stop() }
+  }
+
+  "SQLContextFactory" should {
+    "create SQL context" in {
+      sqlContext = JobContextFactory.makeContext(sqlContextFactoryConfig, "test").asInstanceOf[C]
+      sqlContext.isInstanceOf[SQLContext] mustEqual true
+      sqlContext.sparkContext.isInstanceOf[SparkContext] mustEqual true
+      sqlContext.sparkContext.appName mustEqual "test"
+    }
+
+    "create SQL context on top of specified Spark context factory" in {
+      sqlContext = JobContextFactory.makeContext(hiveSqlFactoryWithCustomSparkContextConfig, "test").asInstanceOf[C]
+      sqlContext.isInstanceOf[HiveContext] mustEqual true
+      sqlContext.sparkContext.isInstanceOf[FakeContext] mustEqual true
+      sqlContext.sparkContext.appName mustEqual "test"
+    }
+  }
+
+  val sqlContextFactoryConfig = ConfigFactory.parseString(
+    """
+      |{
+      |  context.jars = [],
+      |  context.job-context-factory = "context.SparkSQLContextFactory"
+      |  spark.master = "local",
+      |  spark.app.id = "test"
+      |}
+    """.stripMargin).resolve()
+
+  val hiveSqlFactoryWithCustomSparkContextConfig = ConfigFactory.parseString(
+    """
+      |{
+      |  context.jars = [],
+      |  context.job-context-factory = "context.HiveContextFactory"
+      |  context.spark-context-factory = "context.FakeJobContextFactory"
+      |  spark.master = "local",
+      |  spark.app.id = "test"
+      |}
+    """.stripMargin).resolve()
+}

--- a/spark-job-rest-sql/src/test/scala/context/SparkSQLContextFactorySpec.scala
+++ b/spark-job-rest-sql/src/test/scala/context/SparkSQLContextFactorySpec.scala
@@ -1,0 +1,49 @@
+package context
+
+import api.ContextLike
+import com.typesafe.config.ConfigFactory
+import org.apache.spark.sql.SQLContext
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.Try
+
+/**
+ * Test suite for [[HiveContextFactory]].
+ */
+@RunWith(classOf[JUnitRunner])
+class SparkSQLContextFactorySpec extends WordSpec with MustMatchers with BeforeAndAfter {
+  type C = SQLContext with ContextLike
+  
+  var sqlContext: C = _
+  
+  val sqlContextFactory = new SparkSQLContextFactory()
+  
+  // Clean up Spark context after each test
+  after {
+    Try{ sqlContext.stop() }
+  }
+
+  "SQLContextFactory" should {
+    "create SQL context" in {
+      sqlContext = sqlContextFactory.makeContext(config, this.getClass.getName)
+      sqlContext.sparkContext.appName mustEqual this.getClass.getName
+    }
+
+    "stop underlying Spark context if context is stopped" in {
+      sqlContext = sqlContextFactory.makeContext(config, "context1")
+      sqlContext.stop()
+      sqlContext = sqlContextFactory.makeContext(config, "context2")
+      sqlContext.sparkContext.appName mustEqual "context2"
+    }
+  }
+
+  val config = ConfigFactory.parseString(
+    """
+      |{
+      |  context.jars = [],
+      |  spark.master = "local"
+      |}
+    """.stripMargin)
+}

--- a/spark-job-rest/pom.xml
+++ b/spark-job-rest/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.xpatterns</groupId>
 	<artifactId>spark-job-rest</artifactId>
-	<version>0.3.1</version>
+	<version>0.3.2</version>
 	<packaging>jar</packaging>
 
 	<name>spark-job-rest</name>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.xpatterns</groupId>
             <artifactId>spark-job-rest-api</artifactId>
-            <version>0.3.1</version>
+            <version>${version}</version>
         </dependency>
 
         <dependency>
@@ -64,26 +64,23 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.4</version>
-		</dependency>
-
-		<dependency>
 			<groupId>io.spray</groupId>
 			<artifactId>spray-routing</artifactId>
 			<version>${spray.io.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>io.spray</groupId>
 			<artifactId>spray-can</artifactId>
 			<version>${spray.io.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>io.spray</groupId>
 			<artifactId>spray-caching</artifactId>
 			<version>${spray.io.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>
@@ -93,7 +90,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.3.2</version>
+			<version>2.4.4</version>
 		</dependency>
 
 		<dependency>
@@ -113,18 +110,18 @@
             <artifactId>config</artifactId>
             <version>1.2.1</version>
         </dependency>
+
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.7</version>
         </dependency>
+
         <dependency>
             <groupId>org.joda</groupId>
             <artifactId>joda-convert</artifactId>
             <version>1.7</version>
         </dependency>
-
-
 
         <!--Http client-->
         <dependency>
@@ -139,13 +136,7 @@
             <version>4.3.2</version>
         </dependency>
 
-        <!--this is a must in order to connect to zk on redhat-->
-        <!--<dependency>-->
-            <!--<groupId>org.springframework</groupId>-->
-            <!--<artifactId>spring-context-support</artifactId>-->
-            <!--<version>4.0.5.RELEASE</version>-->
-        <!--</dependency>-->
-
+        <!-- Test dependencies -->
         <dependency>
             <groupId>io.spray</groupId>
             <artifactId>spray-testkit</artifactId>
@@ -160,7 +151,22 @@
                     <groupId>com.typesafe.akka</groupId>
                 </exclusion>
             </exclusions>
+			<scope>test</scope>
         </dependency>
+
+		<dependency>
+			<groupId>com.typesafe.akka</groupId>
+			<artifactId>akka-testkit_2.10</artifactId>
+			<version>${akka.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.4</version>
+			<scope>test</scope>
+		</dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>
@@ -170,13 +176,12 @@
         </dependency>
 
         <dependency>
-            <scope>test</scope>
             <groupId>com.xpatterns</groupId>
             <artifactId>spark-job-rest-client</artifactId>
-            <version>0.3.1</version>
+            <version>${version}</version>
+			<scope>test</scope>
         </dependency>
 	</dependencies>
-
 
 	<build>
 		<resources>

--- a/spark-job-rest/src/main/resources/application.conf
+++ b/spark-job-rest/src/main/resources/application.conf
@@ -53,6 +53,12 @@ appConf{
 context{
   # Path to context process work directory
   contexts-base-dir = ${CONTEXTS_BASE_DIR}
+  # Amount of jobs which can be executed on context in parallel. Zero means infinit concurency.
+  cuncurrent-jobs = 0
+  # Context factory that will be dynamically loaded to instantiate job context
+  job-context-factory = "context.HiveContextFactory"
+  # Spark context factory that will be used for non-Spark job contexts (SQL or Hive)
+  spark-context-factory = "context.SparkContextFactory"
 }
 
 manager {

--- a/spark-job-rest/src/main/scala/context/JobContextFactory.scala
+++ b/spark-job-rest/src/main/scala/context/JobContextFactory.scala
@@ -1,0 +1,52 @@
+package context
+
+import api.ContextLike
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+
+import scala.util.Try
+
+trait JobContextFactory {
+  type C <: ContextLike
+  def makeContext(config: Config, contextName: String): C
+}
+
+object JobContextFactory {
+  val logger = LoggerFactory.getLogger(getClass)
+  val defaultFactoryClassName = "context.SparkContextFactory"
+  val classNameConfigEntry = "context.job-context-factory"
+
+  /**
+   * Loads context factory with a class name in `context.factory`
+   * @param config config for context and context factory
+   * @param contextName context name
+   * @return Spark context
+   */
+  def makeContext(config: Config, contextName: String): ContextLike = {
+    val factory = getFactory(config)
+    logger.info(s"Creating context $contextName from factory $factory.")
+    factory.makeContext(config, contextName)
+  }
+
+  /**
+   * Loads context factory from specified class
+   * @param className context factory class
+   * @return
+   */
+  def getFactory(className: String = defaultFactoryClassName): JobContextFactory = {
+    logger.info(s"Loading context factory $className.")
+    Class.forName(className).newInstance().asInstanceOf[JobContextFactory]
+  }
+
+  /**
+   * Loads factory for specified configuration.
+   * If config doesn't contain `context.job-context-factory` than [[JobContextFactory.defaultFactoryClassName]] will be loaded.
+   * @param config config
+   * @return
+   */
+  def getFactory(config: Config): JobContextFactory =
+    getFactory(Try {
+      config.getString(classNameConfigEntry)
+    }.getOrElse(defaultFactoryClassName))
+}
+

--- a/spark-job-rest/src/main/scala/context/JobContextFactory.scala
+++ b/spark-job-rest/src/main/scala/context/JobContextFactory.scala
@@ -3,8 +3,7 @@ package context
 import api.ContextLike
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
-
-import scala.util.Try
+import server.domain.actors.getValueFromConfig
 
 trait JobContextFactory {
   type C <: ContextLike
@@ -45,8 +44,6 @@ object JobContextFactory {
    * @return
    */
   def getFactory(config: Config): JobContextFactory =
-    getFactory(Try {
-      config.getString(classNameConfigEntry)
-    }.getOrElse(defaultFactoryClassName))
+    getFactory(getValueFromConfig(config, classNameConfigEntry, defaultFactoryClassName))
 }
 

--- a/spark-job-rest/src/main/scala/context/SparkContextFactory.scala
+++ b/spark-job-rest/src/main/scala/context/SparkContextFactory.scala
@@ -1,0 +1,25 @@
+package context
+
+import api.{ContextLike, SparkJob, SparkJobBase}
+import com.typesafe.config.Config
+import org.apache.spark.SparkContext
+import org.slf4j.LoggerFactory
+import utils.ContextUtils.configToSparkConf
+
+/**
+ * This is a default implementation for Spark Context factory.
+ */
+class SparkContextFactory extends JobContextFactory {
+  type C = SparkContext with ContextLike
+  val logger = LoggerFactory.getLogger(getClass)
+  
+  def makeContext(config: Config, contextName: String) = {
+    val sparkConf = configToSparkConf(config, contextName)
+    logger.info(s"Creating Spark context $contextName with config $sparkConf.")
+    new SparkContext(sparkConf) with ContextLike {
+      val contextClass = classOf[SparkContext].getName
+      def sparkContext: SparkContext = this.asInstanceOf[SparkContext]
+      def isValidJob(job: SparkJobBase) = job.isInstanceOf[SparkJob]
+    }
+  }
+}

--- a/spark-job-rest/src/main/scala/server/domain/actors/package.scala
+++ b/spark-job-rest/src/main/scala/server/domain/actors/package.scala
@@ -2,10 +2,8 @@ package server.domain
 
 import akka.util.Timeout
 import com.typesafe.config.Config
-import org.apache.spark.SparkConf
 
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
 
 /**
  * Utility functions for actors
@@ -15,13 +13,5 @@ package object actors {
 
   def getValueFromConfig[T](config: Config, configPath: String, defaultValue: T): T ={
     if (config.hasPath(configPath)) config.getAnyRef(configPath).asInstanceOf[T] else defaultValue
-  }
-
-  def configToSparkConf(config:Config, contextName:String, jars: List[String]): SparkConf ={
-    val sparkConf = new SparkConf().setAppName(contextName).setJars(jars)
-    for(x <- config.entrySet().asScala if x.getKey.startsWith("spark.")) {
-      sparkConf.set(x.getKey, x.getValue.unwrapped().toString)
-    }
-    sparkConf
   }
 }

--- a/spark-job-rest/src/main/scala/utils/ContextUtils.scala
+++ b/spark-job-rest/src/main/scala/utils/ContextUtils.scala
@@ -1,0 +1,20 @@
+package utils
+
+import com.typesafe.config.Config
+import org.apache.spark.SparkConf
+
+import scala.collection.JavaConverters._
+
+object ContextUtils {
+  def configToSparkConf(config:Config, contextName:String): SparkConf ={
+    val sparkConf = new SparkConf()
+      .setAppName(contextName)
+      .setJars(config.getStringList("context.jars").asScala)
+
+    for(x <- config.entrySet().asScala if x.getKey.startsWith("spark.")) {
+      sparkConf.set(x.getKey, x.getValue.unwrapped().toString)
+    }
+
+    sparkConf
+  }
+}

--- a/spark-job-rest/src/test/resources/application.conf
+++ b/spark-job-rest/src/test/resources/application.conf
@@ -3,48 +3,60 @@ spark.executor.memory=2g
 spark.mesos.coarse=false
 spark.scheduler.mode=FAIR
 spark.cores.max=2
-spark.master="spark://devbox.local:7077"
-spark.path="/Users/raduc/spark-1.1.0"
+spark.master="local"
+spark.path=${SPARK_HOME}
 spark.default.parallelism=384
 spark.storage.memoryFraction=0.3
 spark.shuffle.memoryFraction=0.6
 spark.shuffle.compress=true
 spark.shuffle.spill-compress=true
 spark.reducer.maxMbInFlight=48
-spark.akka.frameSize=10000
+spark.akka.frameSize=100
 spark.akka.threads=4
 spark.akka.timeout=100
 spark.task.maxFailures=4
 spark.shuffle.consolidateFiles=true
 spark.deploy.spreadOut=true
 spark.shuffle.spill=false
-#Serialization settings commented until more tests are performed
-  #spark.serializer="org.apache.spark.serializer.KryoSerializer"
-  #spark.kryoserializer.buffer-mb=10
-  #spark.kryoserializer.buffer.max-mb=64
 spark.kryo.referenceTracking=false
+
 #Default Spark Driver JVM memory
 driver.xmxMemory = 1g
-#hdfs.namenode = "hdfs://devbox.local:8020"
-
-
 
 # application configuration
 appConf{
-  # this ip on which to deploy the apis
+  # This ip on which to deploy the apis
   web.services.ip="0.0.0.0"
-  # the port on which to deploy the apis
+  # The port on which to deploy the apis
   web.services.port=8097
-  # implicit akka timeout
+  # Implicit akka timeout
   timeout=1000000
-  #implicit sleep before sending init message
-  init.sleep=3000
-  #The port where the range for actor system starts
+  # Remote context initialization
+  init {
+    # Implicit sleep (milliseconds) before sending init message
+    sleep=3000
+    # Tries before consider remote context as dead
+    tries=20
+    # Timeout for each attempt (milliseconds)
+    retry-timeout=1000
+    # Inteval beetween attempts to reach remote context (milliseconds)
+    retry-interval=1500
+  }
+  # The port where the range for actor system starts
   actor.systems.first.port = 11000
-  #The port where the range for spark ui starts
+  # The port where the range for spark ui starts
   spark.ui.first.port = 16000
-  #The path to the folder where to keep the jars
-  jars.path = /Users/raduchilom/projects/spark-job-rest/jars
+  # The path to the folder where to keep the jars
+  jars.path = /tmp/spark-job-rest/jars
+}
+
+context{
+  # Path to context process work directory
+  contexts-base-dir = /tmp/spark-job-rest/contexts
+  # Amount of jobs which can be executed on context in parallel. Zero means infinit concurency.
+  cuncurrent-jobs = 0
+  # Context factory that will be dynamically loaded to instantiate job context
+  job-context-factory = "context.SparkContextFactory"
 }
 
 manager {

--- a/spark-job-rest/src/test/scala/context/JobContextFactorySpec.scala
+++ b/spark-job-rest/src/test/scala/context/JobContextFactorySpec.scala
@@ -1,0 +1,66 @@
+package context
+
+import api.{ContextLike, SparkJobBase}
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.spark.SparkContext
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+trait FakeContext
+
+class FakeJobContextFactory extends JobContextFactory {
+  type C = ContextLike
+  def makeContext(config: Config, contextName: String): ContextLike = new ContextLike with FakeContext {
+    val contextClass = classOf[FakeContext].getName
+    override def stop(): Unit = {}
+    override def isValidJob(job: SparkJobBase): Boolean = true
+    override def sparkContext: SparkContext = null
+  }
+}
+
+/**
+ * Test suite for [[JobContextFactory]].
+ */
+@RunWith(classOf[JUnitRunner])
+class JobContextFactorySpec extends WordSpec with MustMatchers with BeforeAndAfter {
+  "JobContextFactory" should {
+    "load specified factory" in {
+      JobContextFactory
+        .getFactory("context.SparkContextFactory")
+        .isInstanceOf[SparkContextFactory] mustEqual true
+    }
+
+    "load default factory" in {
+      JobContextFactory
+        .getFactory()
+        .isInstanceOf[SparkContextFactory] mustEqual true
+    }
+
+    "make context with default factory if other is not specified" in {
+      val context = JobContextFactory.makeContext(ConfigFactory.parseString(
+        """
+        |{
+        |  context.jars = [],
+        |  spark.master = "local",
+        |  spark.app.id = "test"
+        |}
+        """.stripMargin).resolve(), "test")
+      context.isInstanceOf[SparkContext] mustEqual true
+      context.stop()
+    }
+
+    "make context with specified factory if other is not specified" in {
+      JobContextFactory.makeContext(ConfigFactory.parseString(
+        """
+          |{
+          |  context.jars = [],
+          |  context.job-context-factory = "context.FakeJobContextFactory",
+          |  spark.master = "local",
+          |  spark.app.id = "test"
+          |}
+        """.stripMargin).resolve(), "test")
+        .isInstanceOf[FakeContext] mustEqual true
+    }
+  }
+}

--- a/spark-job-rest/src/test/scala/context/SparkContextFactorySpec.scala
+++ b/spark-job-rest/src/test/scala/context/SparkContextFactorySpec.scala
@@ -1,0 +1,41 @@
+package context
+
+import api.ContextLike
+import com.typesafe.config.ConfigFactory
+import org.apache.spark.SparkContext
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.Try
+
+/**
+ * Test suite for [[SparkContextFactory]].
+ */
+@RunWith(classOf[JUnitRunner])
+class SparkContextFactorySpec extends WordSpec with MustMatchers with BeforeAndAfter {
+  type C = SparkContext with ContextLike
+
+  var sparkContext: C = _
+  val sparkContextFactory = new SparkContextFactory()
+
+  // Destroy Spark context after each test
+  after {
+    Try{ sparkContext.stop() }
+  }
+
+  "SingletonSparkContextFactory" should {
+    "create Spark context" in {
+      sparkContext = sparkContextFactory.makeContext(config, this.getClass.getName)
+      sparkContext.appName mustEqual this.getClass.getName
+    }
+  }
+
+  val config = ConfigFactory.parseString(
+    """
+      |{
+      |  context.jars = [],
+      |  spark.master = "local"
+      |}
+    """.stripMargin)
+}

--- a/spark-job-rest/src/test/scala/server/domain/actors/ContextActorSpec.scala
+++ b/spark-job-rest/src/test/scala/server/domain/actors/ContextActorSpec.scala
@@ -1,0 +1,75 @@
+package server.domain.actors
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.ActorSystem
+import akka.pattern.ask
+import akka.testkit.TestActorRef
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
+import context.{FakeContext, JobContextFactory}
+import org.apache.spark.SparkContext
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.time.SpanSugar._
+
+import scala.util.Success
+
+/**
+ * Test suit for [[ContextActor]]
+ */
+@RunWith(classOf[JUnitRunner])
+class ContextActorSpec extends WordSpec with MustMatchers with BeforeAndAfter with TimeLimitedTests {
+  val timeLimit = 10 seconds
+
+  val config = ConfigFactory.load()
+
+  implicit val timeout = Timeout(10, TimeUnit.SECONDS)
+  implicit val system = ActorSystem("localSystem")
+
+  var contextActorRef: TestActorRef[ContextActor] = _
+  def contextActor = contextActorRef.underlyingActor
+
+  val contextName = "demoContext"
+
+  before {
+    contextActorRef = TestActorRef(new ContextActor(config))
+  }
+
+  after {
+    contextActor.jobContext.stop()
+  }
+
+  "ContextActor" should {
+    "create Spark context when initialized" in {
+      val future = contextActorRef ? ContextActor.Initialize(contextName, config, List())
+      val Success(result: ContextActor.Initialized) = future.value.get
+      result must not equal null
+      contextActor.jobContext.isInstanceOf[SparkContext] mustEqual true
+    }
+
+    "have default factory for Spark context" in {
+      val configWithoutFactory = config.withoutPath(JobContextFactory.classNameConfigEntry)
+      val future = contextActorRef ? ContextActor.Initialize(contextName, configWithoutFactory, List())
+      val Success(result: ContextActor.Initialized) = future.value.get
+      result must not equal null
+      contextActor.jobContext.isInstanceOf[SparkContext] mustEqual true
+    }
+
+    "create context from specified factory" in {
+      val future = contextActorRef ? ContextActor.Initialize(contextName, fakeContextFactoryConfig, List())
+      val Success(result: ContextActor.Initialized) = future.value.get
+      result must not equal null
+      contextActor.jobContext.isInstanceOf[FakeContext] mustEqual true
+    }
+  }
+
+  val fakeContextFactoryConfig = ConfigFactory.parseString(
+    """
+      |{
+      |  context.job-context-factory = "context.FakeJobContextFactory",
+      |}
+    """.stripMargin).withFallback(config)
+}

--- a/spark-job-rest/src/test/scala/server/domain/actors/JarActorTest.scala
+++ b/spark-job-rest/src/test/scala/server/domain/actors/JarActorTest.scala
@@ -1,34 +1,32 @@
-package server.actors
+package server.domain.actors
 
 import java.io.File
+import java.util.concurrent.TimeUnit
 
-import akka.actor.{ActorSystem}
+import akka.actor.ActorSystem
+import akka.pattern.ask
 import akka.testkit.TestActorRef
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.junit.runner.RunWith
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfter, FunSuite, Matchers}
 import responses.JarInfo
 import server.domain.actors.JarActor._
-import server.domain.actors.{JarActor}
-import akka.pattern.ask
-import org.scalatest.Matchers
 import utils.FileUtils
+
 import scala.util.{Random, Success}
 
-
 /**
- * Created by raduchilom on 21/03/15.
+ * Test suite for [[JarActor]].
  */
-
 @RunWith(classOf[JUnitRunner])
 class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with Matchers {
 
   val config = ConfigFactory.load()
 
-  implicit val timeout = Timeout(10000)
+  implicit val timeout = Timeout(10, TimeUnit.SECONDS)
   implicit val system = ActorSystem("localSystem")
 
   val jarActor = TestActorRef(new JarActor(config))
@@ -68,7 +66,7 @@ class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with M
 
     val jarName = Random.nextString(5) + ".jar"
 
-    var future = jarActor ? AddJar(jarName, getTestJarBytes())
+    var future = jarActor ? AddJar(jarName, getTestJarBytes)
     val Success(result: Success[JarInfo]) = future.value.get
     result shouldBe an [Success[JarInfo]]
 
@@ -89,7 +87,7 @@ class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with M
   test("Write 10 Jars") {
     for( i <- 1 to 10) {
       val jarName = Random.nextString(5) + ".jar"
-      var future = jarActor ? AddJar(jarName, getTestJarBytes())
+      var future = jarActor ? AddJar(jarName, getTestJarBytes)
     }
 
     val future = jarActor ? GetAllJarsNames()
@@ -99,7 +97,7 @@ class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with M
 
   test("Get Classpath For Uploaded Jar"){
     val jarName = Random.nextString(5) + ".jar"
-    var future = jarActor ? AddJar(jarName, getTestJarBytes())
+    var future = jarActor ? AddJar(jarName, getTestJarBytes)
 
     future = jarActor ? GetJarsPathForClasspath(jarName, contextName)
     val Success(result: String) = future.value.get
@@ -108,7 +106,7 @@ class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with M
 
   def createLocalJar(jarName: String) = {
     val jarPath = jarFolder + jarName
-    FileUtils.writeToFile(jarName, jarFolder, getTestJarBytes())
+    FileUtils.writeToFile(jarName, jarFolder, getTestJarBytes)
   }
 
   test("Get Classpath For Local Jar"){
@@ -139,7 +137,7 @@ class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with M
     createLocalJar(localJarName)
 
     val jarName = Random.nextString(5) + ".jar"
-    var future = jarActor ? AddJar(jarName, getTestJarBytes())
+    var future = jarActor ? AddJar(jarName, getTestJarBytes)
 
     future = jarActor ? GetJarsPathForClasspath(jarPath + "," + jarName, contextName)
     val Success(result: String) = future.value.get
@@ -148,7 +146,7 @@ class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with M
 
   test("Get Spark Jars For Uploaded Jar"){
     val jarName = Random.nextString(5) + ".jar"
-    var future = jarActor ? AddJar(jarName, getTestJarBytes())
+    var future = jarActor ? AddJar(jarName, getTestJarBytes)
 
     future = jarActor ? GetJarsPathForSpark(jarName)
     val Success(result: List[String]) = future.value.get
@@ -183,7 +181,7 @@ class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with M
     val hdfsJarPath = "hdfs://devbox.local:8020/home/ubuntu/test.jar"
 
     val jarName = Random.nextString(5) + ".jar"
-    var future = jarActor ? AddJar(jarName, getTestJarBytes())
+    var future = jarActor ? AddJar(jarName, getTestJarBytes)
 
     future = jarActor ? GetJarsPathForSpark(jarPath + "," + jarName  + "," + hdfsJarPath)
     val Success(result: List[String]) = future.value.get
@@ -199,7 +197,7 @@ class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with M
 //    val hdfsJarPath = "hdfs://devbox.local:8020/home/ubuntu/test.jar"
 
     val jarName = Random.nextString(5) + ".jar"
-    var future = jarActor ? AddJar(jarName, getTestJarBytes())
+    var future = jarActor ? AddJar(jarName, getTestJarBytes)
 
     future = jarActor ? GetJarsPathForAll(jarPath + "," + jarName, contextName)
     val Success(result: ResultJarsPathForAll) = future.value.get
@@ -208,7 +206,7 @@ class JarActorTest extends FunSuite with BeforeAndAfter with ScalaFutures with M
   }
 
 
-  def getTestJarBytes(): Array[Byte] = {
+  def getTestJarBytes: Array[Byte] = {
     val bytes: Array[Byte] = Array(0x50.toByte, 0x4b.toByte, 0x03.toByte, 0x04.toByte)
 
     val randomBytes = new Array[Byte](20)


### PR DESCRIPTION
With this PR we are allowed to specify context factory.
Additionally we added `spark-job-rest-sql` dependency with `SQLContext` and `HiveContext` factories.
See updated `README.md` for details.
This PR will be used as a base for Spark 1.4 support (#26).